### PR TITLE
chore: integrate CI/CD with Google Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -67,8 +67,6 @@ steps:
       - apply
       - -f
       - $_FILE_TO_DEPLOY
-        # TODO: remove --dry-run when cloudbuild ready
-      - --dry-run=server
       - --validate=true
     env:
       - 'CLOUDSDK_COMPUTE_REGION=asia-east1'


### PR DESCRIPTION
### Preface
**This PR shows a Proof-of-Concept. It could open more discussions about our CI/CD pipelines.**
This repo is already added in Google Cloud Build system. (See https://console.cloud.google.com/cloud-build/builds/e1649562-090e-4b3a-b6d8-b442082a7504?project=mirror-tv-275709)
After this PR merged, all changes pushed into `dev` branch will trigger builds.

(I already build a demo one, please check https://console.cloud.google.com/cloud-build/builds/0a405c3b-528e-44bc-9f63-cea24a5fcfc0?project=mirror-tv-275709)

### Description
In this PR, @hcchien and I create `cloudbuild.yaml` file to specify the CI/CD steps.
In brief, when changes pushed into target branch, say `dev` branch,  the build will and supposed to do
1. clone `openwarehouse` source code to build workspace
2. yarn test (if needed)
3. yarn build
4. docker build  (with `dev` in the tag)
5. push docker image to Google Container registry
6. clone [`kubernetes-config`](https://github.com/mirror-media/kubernetes-configs) to build workspace
7. use `kustomize` to set container image tag to new built one (`dev` one)
8. generate k8s configs related to tv component, including tv-cms, tv-gql-internal and tv-gql-external (we could deploy separately if we want)
9. apply generated k8s configs to target cluster (`tv-dev`).

### What has been changed?
Major changes:
1. drone -> Cloud Build
2. k8s config generator: helm -> kustomize
3. helm release -> kubectl apply 

The reason why I choose `kustomize` to generate k8s configs is explained in https://github.com/mirror-media/kubernetes-configs/pull/1 (See `README.md`)

### Related PRs
https://github.com/mirror-media/kubernetes-configs/pull/1 