### PR TITLE
PoC: improve readability of access control

### DIFF
--- a/helpers/access/mirror-tv.js
+++ b/helpers/access/mirror-tv.js
@@ -21,7 +21,7 @@ const owner = ({ authentication: { item: user }, listKey }) => {
 const registeredUsers = ({ authentication: { item } }) => Boolean(!!item)
 
 // anonymousWithGqlControl depends on process.env.K5_SERVICE_TYPE == GQL
-const anonymousWithGqlControl = ({ gqlControl }) => {
+const anonymousWithGqlControl = ({ gqlServiceControl }) => {
 
     const serviceType = process.env.K5_SERVICE_TYPE || 'CMS'
     let control;
@@ -31,7 +31,7 @@ const anonymousWithGqlControl = ({ gqlControl }) => {
         // then restrict read access via user's role
         // (anonymous can only read public)
         case 'GQL':
-            control = gqlControl
+            control = gqlServiceControl
             break;
 
         // if type of server is Preview,

--- a/lists/mirror-tv/Post.js
+++ b/lists/mirror-tv/Post.js
@@ -277,7 +277,7 @@ module.exports = {
         byTracking(),
     ],
     access: {
-        read: allowRoles(registeredUsers, anonymousWithGqlControl({ gqlControl: { 'state_in': ['published', 'invisible'] } })),
+        read: allowRoles(registeredUsers, anonymousWithGqlControl({ gqlServiceControl: { 'state_in': ['published', 'invisible'] } })),
         // FIXME Do we really want to limit read access of a contributor?
         // read: getAccessControlViaServerType(
         //     admin,


### PR DESCRIPTION
在 PR #40 裡，新增了一個 `getAccessControlViaServerType` 的 function，他可以增加 `Post`, `EditorChoice` 以及 `VideoEditorChoice` 的讀取限制。

# 為什麼這個 PR 很重要

我認為這個實作以及函式命名可能會降低程式的易讀性，而且增加了一個額外的函式，並把 access control 的細節放在實作之內。

在存取控制的部分，如果我們寫得越簡單清晰，維護的負擔也越小，也可以避免實作上的錯誤，讓 GraphQL 更安全。

在這個 PR，我示範了使用已有的 allowRoles 的 function，來達到這個目的。

# 展示程式碼

在 #40 裡 access control 會需要這麼寫

```
    access: {
        read: getAccessControlViaServerType(
            admin,
            bot,
            moderator,
            editor,
            owner
        ),
        update: allowRoles(admin, bot, moderator, editor, owner),
        create: allowRoles(admin, bot, moderator, editor, contributor),
        delete: allowRoles(admin),
    },
```

如果只看函式名稱，並不會知道他有允許了部分的匿名使用者的請求，所以在這個 PR，我利用了 **GraphQLWhere** 更細緻的管控` 以及 currying 的技巧，增加了一個匿名使用者、與所有使用者，使用 allowRoles 來限制讀取的權限，寫法可以改成

```
    access: {
        read: allowRoles(registeredUsers, anonymousWithGqlControl({ gqlServiceControl: { 'state_in': ['published', 'invisible'] } })),
        update: allowRoles(admin, bot, moderator, editor, owner),
        create: allowRoles(admin, bot, moderator, editor, contributor),
        delete: allowRoles(admin),
    },
```

如此一來在調整權限時，就會更容易讀取。