### PR TITLE
feat(mirror-tv): remove defaultValue of heroCaption in Post.js

### DIFF
--- a/lists/mirror-tv/Post.js
+++ b/lists/mirror-tv/Post.js
@@ -129,7 +129,6 @@ module.exports = {
         heroCaption: {
             label: '首圖圖說',
             type: Text,
-            defaultValue: '',
         },
         heroImageSize: {
             label: '首圖尺寸',
@@ -331,7 +330,7 @@ module.exports = {
                 addValidationError
             )
         },
-        beforeChange: async ({ existingItem, resolvedData }) => {},
+        beforeChange: async ({ existingItem, resolvedData }) => { },
     },
     adminConfig: {
         defaultColumns:

--- a/lists/mirror-tv/pq/migrations/002_SetNullableToPostHeroCaption.sql
+++ b/lists/mirror-tv/pq/migrations/002_SetNullableToPostHeroCaption.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."Post" ALTER COLUMN "heroCaption" DROP NOT NULL;


### PR DESCRIPTION
Keystonejs would set the column as NOT NULL, if it has a defaultValue. To follow its behavior, we remove the the defaultValue as we need heroCaption to be able to store the empty valueof string, which is recognized as NULL for GraphQL.

Refs: https://app.asana.com/0/1199959371256159/1200669883612008/f