### PR TITLE
fix(readr): count readingTime if content is not empty and fix the undefined-problem of post-slug

### DIFF
--- a/utils/draftEditorHandler.js
+++ b/utils/draftEditorHandler.js
@@ -1,7 +1,7 @@
 const countReadingTime = async (existingItem, resolvedData) => {
     try {
-        const content = resolvedData?.content
-            ? JSON.parse(resolvedData?.content)
+        const content = resolvedData?.content || existingItem?.content
+            ? JSON.parse(resolvedData?.content || existingItem?.content)
             : undefined
         
         // only edited draft editor need to count readTime
@@ -13,11 +13,9 @@ const countReadingTime = async (existingItem, resolvedData) => {
 
         // if style is replaced to report, clear readingTime and return
         if (reportStyles.includes(resolvedData.style)) {
-            resolvedData.readingTime = null
+            resolvedData.readingTime = 0
             return
         }
-
-        console.log('content', content)
 
         // count words
         let totalWordCount = 0

--- a/utils/validateIfReportPostHaveSlug.js
+++ b/utils/validateIfReportPostHaveSlug.js
@@ -1,11 +1,11 @@
 const validateIfReportPostHaveSlug = (existingItem, resolvedData, addValidationError) => {
-    const currentStyle = resolvedData.style
-    const currentPostSlug = resolvedData.slug || existingItem.slug
+    const currentStyle = resolvedData?.style || existingItem?.style
+    const currentPostSlug = resolvedData?.slug || existingItem?.slug
 
     const needSlug = currentStyle === 'project3' || currentStyle === 'report'
-    const noPublishTime = currentPostSlug === null || typeof currentPostSlug === 'undefined'
+    const noSlug = currentPostSlug === '' || currentPostSlug === null || typeof currentPostSlug === 'undefined'
 
-    if (needSlug && noPublishTime) {
+    if (needSlug && noSlug) {
         addValidationError('若文章樣式為「project3」、「report」，則 Slug 不能空白')
     }
 }


### PR DESCRIPTION
- 描述
1. 為了使舊文章在不需重存的情況下都能重新計算 readingTime，修改為 content 內只要有內容，就跑一次計算。
2. 修正文章初次存檔時，無 slug 所造成的存檔錯誤。