### PR TITLE
feat(tv): add new fields to contact/serie/show

### DIFF
--- a/lists/mirror-tv/Contact.js
+++ b/lists/mirror-tv/Contact.js
@@ -1,4 +1,4 @@
-const { Integer, Slug, Text, Url, Checkbox } = require('@keystonejs/fields')
+const { Integer, Slug, Text, Url, Checkbox, Relationship } = require('@keystonejs/fields')
 const { byTracking } = require('@keystonejs/list-plugins')
 const { atTracking } = require('../../helpers/list-plugins')
 const { uuid } = require('uuidv4')
@@ -126,6 +126,18 @@ module.exports = {
         host: {
             label: '節目主持人',
             type: Checkbox,
+        },
+        relatedShows: {
+            label: '關聯藝文節目',
+            type: Relationship,
+            ref: 'Show.hostName',
+            many: true,
+        },
+        relatedSeries: {
+            label: '關聯節目單元',
+            type: Relationship,
+            ref: 'Serie.relatedContacts',
+            many: true,
         },
         bioApiData: {
             label: 'bio API Data',

--- a/lists/mirror-tv/Serie.js
+++ b/lists/mirror-tv/Serie.js
@@ -96,6 +96,12 @@ module.exports = {
             ref: 'ArtShow.series',
             many: true,
         },
+        relatedContacts: {
+            label: '關聯主持人',
+            type: Relationship,
+            ref: 'Contact.relatedSeries',
+            many: true,
+        },
         introductionApiData: {
             label: 'Introduction API Data',
             type: TextHide,

--- a/lists/mirror-tv/Show.js
+++ b/lists/mirror-tv/Show.js
@@ -69,6 +69,12 @@ module.exports = {
         hostName: {
             label: '主持人姓名',
             type: Relationship,
+            ref: 'Contact.relatedShows',
+            many: true,
+        },
+        staffName: {
+            label: '工作人員姓名',
+            type: Relationship,
             ref: 'Contact',
             many: true,
         },


### PR DESCRIPTION
- 描述
1. 鏡電視 CMS 新增欄位
    - `show` 新增 `staffName` 欄位，reference 至 `contact`。
    - `show` 原有的 `hostName` 欄位，改為 reference 至 `contact `的 `relatedShows` 欄位。
    - `contact` 新增 `relatedSeries` 欄位，reference 至 `serie` 的 `relatedContacts` 欄位。
    - `contact` 新增 `relatedShows` 欄位，reference 至 `show` 的 `hostName` 欄位。
    - `serie` 新增 `relatedContacts` 欄位，reference 至 `contact` 的 `relatedSeries` 欄位。

- 需求
[Asana](https://app.asana.com/0/1201549719467597/1201543805556278)、[PRD](https://paper.dropbox.com/doc/--BZB6T1TUvCsIYQZPZFijqqXOAg-eTrVLXfElBu8pjGuJVnhy)

- 備註
需要再麻煩 @hcchien 協助進行 database migration，謝謝！