### PR TITLE
feat(tv): set some relationshipField(which correspond to Post) to CustomRelationship, add fields in contact/serie/show

### DIFF
--- a/lists/mirror-tv/Contact.js
+++ b/lists/mirror-tv/Contact.js
@@ -1,4 +1,4 @@
-const { Integer, Slug, Text, Url, Checkbox } = require('@keystonejs/fields')
+const { Integer, Slug, Text, Url, Checkbox, Relationship } = require('@keystonejs/fields')
 const { byTracking } = require('@keystonejs/list-plugins')
 const { atTracking } = require('../../helpers/list-plugins')
 const { uuid } = require('uuidv4')
@@ -126,6 +126,18 @@ module.exports = {
         host: {
             label: '節目主持人',
             type: Checkbox,
+        },
+        relatedShows: {
+            label: '關聯藝文節目',
+            type: Relationship,
+            ref: 'Show.hostName',
+            many: true,
+        },
+        relatedSeries: {
+            label: '關聯節目單元',
+            type: Relationship,
+            ref: 'Serie.relatedContacts',
+            many: true,
         },
         bioApiData: {
             label: 'bio API Data',

--- a/lists/mirror-tv/Post.js
+++ b/lists/mirror-tv/Post.js
@@ -20,6 +20,7 @@ const HTML = require('../../fields/HTML')
 const NewDateTime = require('../../fields/NewDateTime/index.js')
 const ImageRelationship = require('../../fields/ImageRelationship')
 const TextHide = require('../../fields/TextHide')
+const CustomRelationship = require('../../fields/CustomRelationship')
 const cacheHint = require('../../helpers/cacheHint')
 
 const { parseResolvedData } = require('../../utils/parseResolvedData')
@@ -184,7 +185,7 @@ module.exports = {
         },
         relatedPosts: {
             label: '相關文章',
-            type: Relationship,
+            type: CustomRelationship,
             ref: 'Post',
             many: true,
         },

--- a/lists/mirror-tv/Serie.js
+++ b/lists/mirror-tv/Serie.js
@@ -96,6 +96,12 @@ module.exports = {
             ref: 'ArtShow.series',
             many: true,
         },
+        relatedContacts: {
+            label: '關聯主持人',
+            type: Relationship,
+            ref: 'Contact.relatedSeries',
+            many: true,
+        },
         introductionApiData: {
             label: 'Introduction API Data',
             type: TextHide,

--- a/lists/mirror-tv/Show.js
+++ b/lists/mirror-tv/Show.js
@@ -69,6 +69,12 @@ module.exports = {
         hostName: {
             label: '主持人姓名',
             type: Relationship,
+            ref: 'Contact.relatedShows',
+            many: true,
+        },
+        staffName: {
+            label: '工作人員姓名',
+            type: Relationship,
             ref: 'Contact',
             many: true,
         },

--- a/lists/mirror-tv/Topic.js
+++ b/lists/mirror-tv/Topic.js
@@ -9,6 +9,7 @@ const {
 } = require('@keystonejs/fields')
 const HTML = require('../../fields/HTML')
 const TextHide = require('../../fields/TextHide')
+const CustomRelationship = require('../../fields/CustomRelationship')
 const { byTracking } = require('@keystonejs/list-plugins')
 const { atTracking } = require('../../helpers/list-plugins')
 const { uuid } = require('uuidv4')
@@ -93,7 +94,7 @@ module.exports = {
         },
         post: {
             label: 'POST',
-            type: Relationship,
+            type: CustomRelationship,
             ref: 'Post',
             many: true,
         },

--- a/lists/mirror-tv/pq/migrations/011_NEW_FIELDS_FOR_CONTACT.sql
+++ b/lists/mirror-tv/pq/migrations/011_NEW_FIELDS_FOR_CONTACT.sql
@@ -1,0 +1,101 @@
+
+CREATE TABLE public."Contact_relatedSeries_Serie_relatedContacts" (
+    "Contact_left_id" integer NOT NULL,
+    "Serie_right_id" integer NOT NULL
+);
+
+CREATE TABLE public."Contact_relatedShows_Show_hostName" (
+    "Contact_left_id" integer NOT NULL,
+    "Show_right_id" integer NOT NULL
+);
+
+--
+-- Name: contact_relatedshows_show_hostname_contact_left_id_index; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+
+CREATE INDEX contact_relatedshows_show_hostname_contact_left_id_index ON public."Contact_relatedShows_Show_hostName" USING btree ("Contact_left_id");
+
+
+--
+-- Name: contact_relatedshows_show_hostname_show_right_id_index; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+
+CREATE INDEX contact_relatedshows_show_hostname_show_right_id_index ON public."Contact_relatedShows_Show_hostName" USING btree ("Show_right_id");
+--
+-- Name: contact_relatedseries_serie_relatedcontacts_contact_left_id_ind; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+--
+-- Name: Contact_relatedShows_Show_hostName contact_relatedshows_show_hostname_contact_left_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Contact_relatedShows_Show_hostName"
+    ADD CONSTRAINT contact_relatedshows_show_hostname_contact_left_id_foreign FOREIGN KEY ("Contact_left_id") REFERENCES public."Contact"(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Contact_relatedShows_Show_hostName contact_relatedshows_show_hostname_show_right_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Contact_relatedShows_Show_hostName"
+    ADD CONSTRAINT contact_relatedshows_show_hostname_show_right_id_foreign FOREIGN KEY ("Show_right_id") REFERENCES public."Show"(id) ON DELETE CASCADE;
+
+
+CREATE INDEX contact_relatedseries_serie_relatedcontacts_contact_left_id_ind ON public."Contact_relatedSeries_Serie_relatedContacts" USING btree ("Contact_left_id");
+
+--
+-- Name: Contact_relatedSeries_Serie_relatedContacts contact_relatedseries_serie_relatedcontacts_contact_left_id_for; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Contact_relatedSeries_Serie_relatedContacts"
+    ADD CONSTRAINT contact_relatedseries_serie_relatedcontacts_contact_left_id_for FOREIGN KEY ("Contact_left_id") REFERENCES public."Contact"(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Contact_relatedSeries_Serie_relatedContacts contact_relatedseries_serie_relatedcontacts_serie_right_id_fore; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Contact_relatedSeries_Serie_relatedContacts"
+    ADD CONSTRAINT contact_relatedseries_serie_relatedcontacts_serie_right_id_fore FOREIGN KEY ("Serie_right_id") REFERENCES public."Serie"(id) ON DELETE CASCADE;
+
+--
+-- Name: contact_relatedseries_serie_relatedcontacts_serie_right_id_inde; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+
+CREATE INDEX contact_relatedseries_serie_relatedcontacts_serie_right_id_inde ON public."Contact_relatedSeries_Serie_relatedContacts" USING btree ("Serie_right_id");
+--
+--
+-- Name: Contact_relatedSeries_Serie_relatedContacts; Type: TABLE; Schema: public; Owner: keystone_agent
+--
+CREATE TABLE public."Show_staffName_many" (
+    "Show_left_id" integer NOT NULL,
+    "Contact_right_id" integer NOT NULL
+);
+
+--
+-- Name: show_staffname_many_contact_right_id_index; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+
+CREATE INDEX show_staffname_many_contact_right_id_index ON public."Show_staffName_many" USING btree ("Contact_right_id");
+
+
+--
+-- Name: show_staffname_many_show_left_id_index; Type: INDEX; Schema: public; Owner: keystone_agent
+--
+
+CREATE INDEX show_staffname_many_show_left_id_index ON public."Show_staffName_many" USING btree ("Show_left_id");
+
+--
+-- Name: Show_staffName_many show_staffname_many_contact_right_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Show_staffName_many"
+    ADD CONSTRAINT show_staffname_many_contact_right_id_foreign FOREIGN KEY ("Contact_right_id") REFERENCES public."Contact"(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Show_staffName_many show_staffname_many_show_left_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: keystone_agent
+--
+
+ALTER TABLE ONLY public."Show_staffName_many"
+    ADD CONSTRAINT show_staffname_many_show_left_id_foreign FOREIGN KEY ("Show_left_id") REFERENCES public."Show"(id) ON DELETE CASCADE;
+

--- a/utils/publishTimeHandler.js
+++ b/utils/publishTimeHandler.js
@@ -60,7 +60,9 @@ const validateIfPublishTimeIsFutureTime = async (
               currentPublishTime - nowTime >= -3600000 &&
               currentPublishTime - nowTime < 0
             
-            if (!publishTimeIsNow) {
+            const hasCangeStateOrPublishTime = resolvedData.state || resolvedData.publishTime
+            
+            if (hasCangeStateOrPublishTime && !publishTimeIsNow) {
               addValidationError('若狀態為「Published」，則發佈時間必須是現在')
             }
         }


### PR DESCRIPTION
### Notable Change
tv的兩個list：

1. Post
2. Topic
其中都有和Post連動的relationship field，然而對於使用AdminUI的使用者而言，該relationship需要能看到post的slug以及name；不過在之前的EditorChoice相關需求中，有實作了一個新的custom field：CustomRelationship，因此只要將這個custom field套用至需要的地方即可。

add fields in contact/serie/show