### PR TITLE
feat: adjust access-control for contributor in post/sale/sponsor/topic lists

### DIFF
--- a/lists/mirror-tv/Post.js
+++ b/lists/mirror-tv/Post.js
@@ -287,7 +287,7 @@ module.exports = {
             contributor,
             owner
         ),
-        update: allowRoles(admin, bot, moderator, owner),
+        update: allowRoles(admin, bot, moderator, contributor, owner),
         create: allowRoles(admin, bot, moderator, editor, contributor),
         delete: allowRoles(admin, moderator),
     },

--- a/lists/mirror-tv/Sale.js
+++ b/lists/mirror-tv/Sale.js
@@ -33,6 +33,14 @@ module.exports = {
             type: Select,
             options: 'draft, published, scheduled, archived',
             defaultValue: 'draft',
+            access: {
+                // 如果user.role是contributor 那將不能發佈文章（draft以外的狀態）
+                // 所以在此不給contributor有更動post.state的create/update權限
+                // 但又因post.state的defaultValue是draft
+                // 所以也就變相地達到contributor只能發佈draft的要求
+                create: allowRoles(admin, moderator, editor),
+                update: allowRoles(admin, moderator, editor),
+            },
         },
         startTime:{
             label: '起始日期',
@@ -63,8 +71,8 @@ module.exports = {
             contributor,
             owner
         ),
-        update: allowRoles(admin, moderator, editor, bot),
-        create: allowRoles(admin, moderator, editor),
+        update: allowRoles(admin, moderator, editor, contributor, bot),
+        create: allowRoles(admin, moderator, editor, contributor),
         delete: allowRoles(admin, moderator),
     },
     hooks: {},

--- a/lists/mirror-tv/Sponsor.js
+++ b/lists/mirror-tv/Sponsor.js
@@ -1,4 +1,4 @@
-const { Integer, Relationship, Url } = require('@keystonejs/fields')
+const { Integer, Select, Relationship, Url } = require('@keystonejs/fields')
 
 const { byTracking } = require('@keystonejs/list-plugins')
 const { atTracking } = require('../../helpers/list-plugins')
@@ -6,7 +6,6 @@ const {
     admin,
     moderator,
     editor,
-
     contributor,
     allowRoles,
 } = require('../../helpers/access/mirror-tv')
@@ -19,6 +18,20 @@ module.exports = {
             label: '排序順位',
             type: Integer,
             isUnique: true,
+        },
+        state: {
+            label: '狀態',
+            type: Select,
+            options: 'draft, published',
+            defaultValue: 'draft',
+            access: {
+                // 如果user.role是contributor 那將不能發佈文章（draft以外的狀態）
+                // 所以在此不給contributor有更動post.state的create/update權限
+                // 但又因post.state的defaultValue是draft
+                // 所以也就變相地達到contributor只能發佈draft的要求
+                create: allowRoles(admin, moderator, editor),
+                update: allowRoles(admin, moderator, editor),
+            },
         },
         topic: {
             label: '專題',

--- a/lists/mirror-tv/Topic.js
+++ b/lists/mirror-tv/Topic.js
@@ -17,6 +17,7 @@ const {
     admin,
     moderator,
     editor,
+    contributor,
     allowRoles,
 } = require('../../helpers/access/mirror-tv')
 
@@ -121,6 +122,14 @@ module.exports = {
             type: Select,
             options: 'draft, published',
             defaultValue: 'draft',
+            access: {
+                // 如果user.role是contributor 那將不能發佈文章（draft以外的狀態）
+                // 所以在此不給contributor有更動post.state的create/update權限
+                // 但又因post.state的defaultValue是draft
+                // 所以也就變相地達到contributor只能發佈draft的要求
+                create: allowRoles(admin, moderator, editor),
+                update: allowRoles(admin, moderator, editor),
+            },
         },
         brief: {
             label: '前言',
@@ -204,8 +213,8 @@ module.exports = {
         byTracking(),
     ],
     access: {
-        update: allowRoles(admin, moderator, editor),
-        create: allowRoles(admin, moderator, editor),
+        update: allowRoles(admin, moderator, editor, contributor),
+        create: allowRoles(admin, moderator, editor, contributor),
         delete: allowRoles(admin, moderator),
     },
     hooks: {


### PR DESCRIPTION
- 描述
1. 更改 `Post/Sponsor/Topic/Sale` 的 `contributor` 角色權限，使 `contributor` 可以新增、修改以上 list，但不能修改其中的 `state` 欄位。
2. Sponsor 原本沒有 state 欄位，也在此份 PR 新增，但未更新 DB。
3. 更新 DB 的部分需要再麻煩後端協助。

- 需求
[Asana](https://app.asana.com/0/1202159240351287/1202180606679677)