### PR TITLE
chore: adjust fluent-ffmpeg version for Node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "draft-js": "^0.11.7",
         "draftjs-conductor": "^2.0.0",
         "express": "^4.17.1",
-        "fluent-ffmpeg": "^2.1.3",
+        "fluent-ffmpeg": "2.0.1",
         "get-audio-duration": "^2.0.3",
         "get-video-duration": "^3.0.2",
         "htmlparser2": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5205,10 +5205,10 @@ async-retry@^1.2.1, async-retry@^1.3.1:
   dependencies:
     retry "0.12.0"
 
-async@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-  integrity sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==
+async@>=0.2.9:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 async@^3.2.0:
   version "3.2.0"
@@ -7913,13 +7913,12 @@ flatstr@^1.0.12:
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
   integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
 
-fluent-ffmpeg@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz#d6846be257777844249a4adeb320f25326d239f3"
-  integrity sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==
+fluent-ffmpeg@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fluent-ffmpeg/-/fluent-ffmpeg-2.0.1.tgz#4dddcbb82da348158380d5282d21fd4ea64bf4ce"
+  integrity sha512-WeKecGNx8lATeB/je+V8PBkC288Ib2p0+2OUcRfzL4kx9uHNY3XQNxgeZiw3o4W9oyAzLTHR/W6TZykckt5Pqw==
   dependencies:
-    async "^0.2.9"
-    which "^1.1.1"
+    async ">=0.2.9"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -14499,7 +14498,7 @@ which-typed-array@^1.1.2:
     has-symbols "^1.0.1"
     is-typed-array "^1.1.3"
 
-which@^1.1.1, which@^1.2.14:
+which@^1.2.14:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
變更事項：
- 調降 `fluent-ffmpeg` 版本以符合現有 Node 版本